### PR TITLE
Add Linux setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # corail_scrapper
+
+Scripts pour récupérer et visualiser les conventions collectives publiées sur le site Corail.
+
+## Interface web
+
+Le script `visualisation.py` lance une petite application Flask qui affiche les données de `syndicats.db`.
+
+### Sous Linux
+
+```bash
+chmod +x setup_env.sh
+./setup_env.sh
+```
+
+Le script crée un environnement virtuel, installe les dépendances (Flask, pandas) puis démarre le serveur disponible sur http://127.0.0.1:5000.
+
+### Sous Windows
+
+Exécuter `setup_env.bat` et suivre les indications.

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+VENV_NAME="venv"
+
+# Check Python 3 availability
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "❌ Python 3 is required but not installed." >&2
+  exit 1
+fi
+
+PYTHON=${PYTHON:-python3}
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "$VENV_NAME" ]; then
+  echo "✅ Creating virtual environment using $PYTHON..."
+  $PYTHON -m venv "$VENV_NAME"
+fi
+
+# Activate virtual environment
+source "$VENV_NAME/bin/activate"
+
+# Upgrade pip
+$PYTHON -m pip install --upgrade pip
+
+# Install dependencies
+echo "✅ Installing dependencies..."
+pip install flask pandas
+
+# Launch Flask application
+echo "🚀 Launching Flask application..."
+$PYTHON visualisation.py


### PR DESCRIPTION
## Summary
- Add `setup_env.sh` to prepare environment and run the Flask visualisation on Linux
- Document Linux and Windows launch steps in README

## Testing
- `bash -n setup_env.sh`
- `./setup_env.sh` (server started then terminated)


------
https://chatgpt.com/codex/tasks/task_e_6894c1b32df4832b83dd40186eabe504